### PR TITLE
Modify exit code when running into a failed test and added examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ services:
   - docker
 
 script:
-  - docker run -v $(pwd):/var/idris-project pheymann/idris-travis:1.0 ./project --testCI
+  - docker run -v $(pwd):/var/idris-project pheymann/idris-travis:1.0 ./project --test

--- a/examples/SpecExample.idr
+++ b/examples/SpecExample.idr
@@ -1,0 +1,34 @@
+module SpecExample
+
+import Specdris.Spec
+
+%access export
+%default total
+
+add : Nat -> Nat -> Nat
+add a b = a + b
+
+addSpec : SpecTree
+addSpec = describe "Add two Nats" $ do
+            it "neutral element" $ do
+              (1 `add` 0) === 1
+            it "be associative" $ do
+              ((1 `add` 2) `add` 3) === (1 `add` (2 `add` 3))
+            it "be commutative" $ do
+              (1 `add` 2) === (2 `add` 1)
+
+multi : Nat -> Nat -> Nat
+multi a b = a * b
+
+multiSpec : SpecTree
+multiSpec = describe "Multiply two Nats" $ do
+              it "neutral element" $ do
+                (2 `multi` 1) === 2
+              it "be associative" $ do
+                ((1 `multi` 2) `multi` 3) === (1 `multi` (2 `multi` 3))
+              it "be commutative" $ do
+                (1 `multi` 2) === (2 `multi` 1)
+
+specSuite : IO ()
+specSuite = spec $ do addSpec
+                      multiSpec

--- a/examples/SpecIOExample.idr
+++ b/examples/SpecIOExample.idr
@@ -1,0 +1,40 @@
+module SpecIOExample
+
+import Specdris.SpecIO
+
+%access private
+%default total
+
+startDb : IO ()
+startDb = putStrLn "start database ..."
+
+stopDb : IO ()
+stopDb = putStrLn "... stoped database"
+
+testData : IO SpecResult -> IO SpecResult
+testData resultIO = do putStrLn "insert test data"
+                       result <- resultIO
+                       putStrLn "delete test data"
+                       
+                       pure result
+
+record User where
+  constructor MkUser
+  
+  id : Nat
+  name : String
+
+getUser : Nat -> IO User
+getUser id = pure (MkUser id "foo")
+
+getUserSpec : SpecTree
+getUserSpec = describe "User table" $ do
+                it "get a user by id" $ do
+                  user <- getUser 0
+                  
+                  pure $ do (name user) === "foo"
+
+export
+specSuite : IO ()
+specSuite = specIO {beforeAll = startDb} {around = testData} {afterAll = stopDb} $ do 
+              getUserSpec

--- a/examples/example.iqkg
+++ b/examples/example.iqkg
@@ -1,0 +1,9 @@
+package examples
+
+pkgs = specdris
+
+modules = SpecExample,
+          SpecIOExample
+
+tests = SpecExample.specSuite,
+        SpecIOExample.specSuite

--- a/project
+++ b/project
@@ -13,20 +13,16 @@ clean()
 test()
 {
     echo "test project"
-    cd test; idris --testpkg ${test}; cd ..
-}
+    cd test
+    idris --testpkg ${test}
 
-testCI()
-{
-    output=$(test)
-    $(echo -e ${output})
-
-    if $(echo -e ${output}) | grep -q " - FAILED"; then
+    if [[ $? -eq 0 ]]; then
+        echo "SUCCESSFUL"
+    else
         echo "FAILURE"
         exit 1
-    else
-        echo "SUCCESS"
     fi
+    cd ..
 }
 
 buildNoTest()
@@ -46,7 +42,13 @@ install()
     echo "install project"
     clean
     test
-    idris --install ${project}
+
+    if [[ $? -eq 0 ]]; then
+        idris --install ${project}
+    else
+        echo "couldn't install project > something went wrong"
+        exit 1
+    fi
 }
 
 case $1 in
@@ -61,9 +63,6 @@ case $1 in
         ;;
     "--test")
         test
-        ;;
-    "--testCI")
-        testCI
         ;;
     "--install")
         install

--- a/src/Specdris/Spec.idr
+++ b/src/Specdris/Spec.idr
@@ -1,6 +1,8 @@
 ||| Central module use to import the Specdris test framework
 module Specdris.Spec
 
+import System
+
 import public Specdris.Data.SpecState
 import public Specdris.Data.SpecResult
 import public Specdris.Data.SpecInfo
@@ -44,5 +46,8 @@ specWithState {storeOutput} tree
 ||| Executes a spec test and prints the result to the command line.
 spec : SpecTree -> IO ()
 spec tree
-  = do specWithState tree
-       pure ()
+  = do state <- specWithState tree
+       if (failed state) > 0 then
+         exitFailure
+       else
+         pure ()

--- a/src/Specdris/SpecIO.idr
+++ b/src/Specdris/SpecIO.idr
@@ -2,6 +2,8 @@
 ||| io code.
 module Specdris.SpecIO
 
+import System
+
 import public Specdris.Data.SpecState
 import public Specdris.Data.SpecResult
 import public Specdris.Data.SpecInfo
@@ -40,14 +42,14 @@ noAround spec = spec
 ||| @ beforeAll `IO` effect which will be executed before the spec test (optional)
 ||| @ afterAll  `IO` effect which will be executed after the spec test (optional)
 ||| @ around a function to perform effects before/after every spec case (optional)
-specWithState : {default defaultIO beforeAll : IO ()} ->
-                {default defaultIO afterAll : IO ()} ->
-                {default noAround around : IO SpecResult -> IO SpecResult} ->
-                {default False storeOutput : Bool} ->
+specIOWithState : {default defaultIO beforeAll : IO ()} ->
+                  {default defaultIO afterAll : IO ()} ->
+                  {default noAround around : IO SpecResult -> IO SpecResult} ->
+                  {default False storeOutput : Bool} ->
                 
-                SpecTree -> 
-                IO SpecState
-specWithState {beforeAll} {around} tree {afterAll} {storeOutput}
+                  SpecTree -> 
+                  IO SpecState
+specIOWithState {beforeAll} {around} tree {afterAll} {storeOutput}
   = do beforeAll
        state <- evaluate around storeOutput tree
        afterAll
@@ -67,13 +69,16 @@ specWithState {beforeAll} {around} tree {afterAll} {storeOutput}
 ||| @ beforeAll `IO` effect which will be executed before the spec test (optional)
 ||| @ afterAll  `IO` effect which will be executed after the spec test (optional)
 ||| @ around a function to perform effects before/after every spec case (optional)
-spec : {default defaultIO beforeAll : IO ()} ->
-       {default defaultIO afterAll : IO ()} ->
-       {default noAround around : IO SpecResult -> IO SpecResult} ->
-       {default False storeOutput : Bool} ->
+specIO : {default defaultIO beforeAll : IO ()} ->
+         {default defaultIO afterAll : IO ()} ->
+         {default noAround around : IO SpecResult -> IO SpecResult} ->
+         {default False storeOutput : Bool} ->
        
-       SpecTree ->
-       IO ()
-spec {beforeAll} {around} tree {afterAll} {storeOutput}
-  = do specWithState {beforeAll = beforeAll} {afterAll = afterAll} {around = around} {storeOutput = storeOutput} tree
-       pure ()
+         SpecTree ->
+         IO ()
+specIO {beforeAll} {around} tree {afterAll} {storeOutput}
+  = do state <- specIOWithState {beforeAll = beforeAll} {afterAll = afterAll} {around = around} {storeOutput = storeOutput} tree
+       if (failed state) > 0 then
+         exitFailure
+       else
+         pure ()

--- a/test/Specdris/SpecIOTest.idr
+++ b/test/Specdris/SpecIOTest.idr
@@ -5,7 +5,7 @@ import Specdris.TestUtil
 
 testCase : IO ()
 testCase
-  = do state <- specWithState $ do
+  = do state <- specIOWithState $ do
              describe "context 1" $ do
                describe "context 1.1" $ do
                  it "context 1.1.1" $ do
@@ -25,7 +25,7 @@ testCase
 
 withBeforeAndAfterAll : IO ()
 withBeforeAndAfterAll
-  = do state <- specWithState {beforeAll = putStrLn "beforeAll"} {afterAll = putStrLn "afterAll"} $ do
+  = do state <- specIOWithState {beforeAll = putStrLn "beforeAll"} {afterAll = putStrLn "afterAll"} $ do
                   describe "context 1" $ do
                     it "context 1.1" $ do
                       pure $ 1 === 1
@@ -42,7 +42,7 @@ around spec = do putStrLn "before"
 
 withAround : IO ()
 withAround
-  = do state <- specWithState {around = around} $ do
+  = do state <- specIOWithState {around = around} $ do
                   describe "context 1" $ do
                     it "context 1.1" $ do
                       putStrLn "      => expectation"

--- a/test/Specdris/TestUtil.idr
+++ b/test/Specdris/TestUtil.idr
@@ -1,11 +1,14 @@
 module Specdris.TestUtil
 
+import System
+
 %access export
 
 total
 testAndPrint : (Show a, Eq a) => (info : String) -> a -> a -> (a -> a -> Bool) -> IO ()
 testAndPrint info a b predicate 
   = if predicate a b then
-      putStrLn $ " + SUCCESS " ++ info
+      pure ()
     else do 
       putStrLn $ " - FAILED  " ++ info ++ ":\nactual   = " ++ show a ++ "\nexpected = " ++ show b
+      exitFailure


### PR DESCRIPTION
Furthermore I renamed `Specdris.SpecIO.spec` to `Specdris.SpecIO.specIO` (fix).