### PR TITLE
Increased readability of error output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You can also nest `describe`. When executed this spec it will produce the follow
 This is my math test
   + adds two natural numbers
   + multiplies two natural numbers
-    [x] 4 /= 3 -- red
+    [x] not equal --read
+        actual:   4
+        expected: 3
   + do fancy stuff with complex numbers
     [] pending: do this later -- yellow
     

--- a/src/Specdris/Expectations.idr
+++ b/src/Specdris/Expectations.idr
@@ -22,7 +22,7 @@ shouldBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
 shouldBe actual expected = if actual == expected then
                              Success
                            else
-                             BinaryFailure actual expected "/="
+                             BinaryFailure actual expected "not equal"
 
 infixr 7 ===
 
@@ -35,7 +35,7 @@ shouldNotBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
 shouldNotBe actual expected = if actual /= expected then
                                 Success
                               else
-                                BinaryFailure actual expected "=="
+                                BinaryFailure actual expected "equal"
 
 infixr 7 /==
 

--- a/test/Specdris/OutputTest.idr
+++ b/test/Specdris/OutputTest.idr
@@ -4,12 +4,13 @@ import Specdris.Spec
 import Specdris.TestUtil
 
 expected : List String
-expected = ["\ESC[37m  context 1\ESC[0m", "\ESC[37m    context 1.1\ESC[0m",
-            "\ESC[37m      + context 1.1.1\ESC[0m",
-            "\ESC[31m         [x] 1 /= 2\ESC[0m",
-            "\ESC[37m    + context 1.2\ESC[0m",
-            "\ESC[31m       [x] 1 /= 2\ESC[0m",
-            "\ESC[37m    + context 1.3\ESC[0m",
+expected = ["\ESC[37m  context 1\ESC[0m", 
+            "\ESC[37m    context 1.1\ESC[0m", 
+            "\ESC[37m      + context 1.1.1\ESC[0m", 
+            "\ESC[31m         [x] not equal\n             actual:   1\n             expected: 2\ESC[0m", 
+            "\ESC[37m    + context 1.2\ESC[0m", 
+            "\ESC[31m       [x] not equal\n           actual:   1\n           expected: 2\ESC[0m", 
+            "\ESC[37m    + context 1.3\ESC[0m", 
             "\ESC[33m       [] pending: for some reason\ESC[0m"]
 
 testCase : IO ()


### PR DESCRIPTION
From:

```
  [x] <actual> <reason> <expected>
```

to

```
  [x] <reason>
       actual:      <actual>
       expected: <expected>
```