### PR TITLE
Removed state logging from spec(IO)?WithState calls.

### DIFF
--- a/src/Specdris/Data/SpecState.idr
+++ b/src/Specdris/Data/SpecState.idr
@@ -1,5 +1,7 @@
 module Specdris.Data.SpecState
 
+import Specdris.Data.ConsoleColor
+
 %access export
 %default total
 
@@ -54,3 +56,10 @@ outputToStr : SpecState -> Maybe String
 outputToStr state = case output state of
                       (Just out) => Just $ foldl (\acc, line => acc ++ line ++ "\n") "" out
                       Nothing    => Nothing
+
+stateToStr : SpecState -> String
+stateToStr state
+  = colorise (if failed state == 0 then Green else Red) $
+      indent 1
+         ++ (if failed state == 0 then "Passed" else "Failed") ++ ": "
+         ++ show state

--- a/src/Specdris/Spec.idr
+++ b/src/Specdris/Spec.idr
@@ -28,25 +28,18 @@ it : (description : String) -> SpecResult -> SpecTree
 it descr spec = Node (Leaf $ Left $ It $ descr)
                      (Leaf $ Right $ pure spec)
 
-||| Executes a spec test and prints the result to the command line.
+||| Executes a spec test.
 specWithState : {default False storeOutput : Bool} -> SpecTree -> IO SpecState
 specWithState {storeOutput} tree
-  = do state <- evaluate (\spec => spec) storeOutput tree
-       
-       putStrLn $ "\n" ++ stateToStr state
-       pure state
-  where
-    stateToStr : SpecState -> String
-    stateToStr state
-      = colorise (if failed state == 0 then Green else Red) $
-          indent 1
-            ++ (if failed state == 0 then "Passed" else "Failed") ++ ": "
-            ++ show state
+  = evaluate (\spec => spec) storeOutput tree
 
 ||| Executes a spec test and prints the result to the command line.
 spec : SpecTree -> IO ()
 spec tree
   = do state <- specWithState tree
+  
+       putStrLn $ "\n" ++ stateToStr state
+       
        if (failed state) > 0 then
          exitFailure
        else

--- a/src/Specdris/SpecIO.idr
+++ b/src/Specdris/SpecIO.idr
@@ -37,7 +37,7 @@ defaultIO = pure ()
 noAround : IO SpecResult -> IO SpecResult
 noAround spec = spec
 
-||| Executes a spec test and prints the result to the command line.
+||| Executes a spec test.
 |||
 ||| @ beforeAll `IO` effect which will be executed before the spec test (optional)
 ||| @ afterAll  `IO` effect which will be executed after the spec test (optional)
@@ -53,16 +53,8 @@ specIOWithState {beforeAll} {around} tree {afterAll} {storeOutput}
   = do beforeAll
        state <- evaluate around storeOutput tree
        afterAll
-       
-       putStrLn $ "\n" ++ stateToStr state
+
        pure state
-  where
-    stateToStr : SpecState -> String
-    stateToStr state
-      = colorise (if failed state == 0 then Green else Red) $
-          indent 1
-            ++ (if failed state == 0 then "Passed" else "Failed") ++ ": "
-            ++ show state
 
 ||| Executes a spec test and prints the result to the command line.
 |||
@@ -78,6 +70,9 @@ specIO : {default defaultIO beforeAll : IO ()} ->
          IO ()
 specIO {beforeAll} {around} tree {afterAll} {storeOutput}
   = do state <- specIOWithState {beforeAll = beforeAll} {afterAll = afterAll} {around = around} {storeOutput = storeOutput} tree
+    
+       putStrLn $ "\n" ++ stateToStr state
+       
        if (failed state) > 0 then
          exitFailure
        else


### PR DESCRIPTION
Also I removed the redundant implementation of `stateToStr`.