### PR TITLE
[Feature Idea] Allow expectations to return values

### DIFF
--- a/examples/SpecExample.idr
+++ b/examples/SpecExample.idr
@@ -31,6 +31,12 @@ multiSpec = describe "Multiply two Nats" $ do
               it "be commutative" $ do
                 (1 `multi` 2) === (2 `multi` 1)
 
+justASpec : SpecTree
+justASpec = describe "Two-part test" $ do
+              it "3 should map to 'b'" $ do
+                x <- shouldBeJust (lookup 3 [(4, 'a'), (3, 'b')])
+                x === 'b'
+
 partial
 specSuite : IO ()
 specSuite = do seed <- System.time
@@ -38,3 +44,4 @@ specSuite = do seed <- System.time
                          multiSpec
                          (shuffle multiSpec 999999)
                          (shuffle multiSpec seed)
+                         justASpec

--- a/src/Specdris/Core.idr
+++ b/src/Specdris/Core.idr
@@ -15,7 +15,7 @@ data Tree : Type -> Type where
 
 public export
 SpecTree : Type
-SpecTree = Tree (Either SpecInfo (IO SpecResult))
+SpecTree = Tree (Either SpecInfo (IO (SpecResult ())))
 
 namespace SpecTreeDo
   (>>=) : SpecTree -> (() -> SpecTree) -> SpecTree
@@ -24,13 +24,13 @@ namespace SpecTreeDo
 
 {- Evaluates every leaf in the `SpecTree` and folds the different `IO`s to collect
    a final `SpecState`.
-   
+
    Test:
      describe "a" $ do
        describe "b" $ do
          it "c" test_io_c
        it "d" test_io_d
-   
+
    Tree from Test:
                         Node
                          |
@@ -38,11 +38,11 @@ namespace SpecTreeDo
          |                                |
     Leaf Desc "a"                        Node
                                           |
-                                 ---------------------         
+                                 ---------------------
                                  |                   |
                                 Node                Node
                                  |                   |
-                       -------------               --------------- 
+                       -------------               ---------------
                        |           |               |             |
                  Leaf Desc "b"    Node        Leaf It "d"  Leaf test_io_d
                                    |
@@ -50,17 +50,17 @@ namespace SpecTreeDo
                             |              |
                        Leaf It "c"   Leaf test_io_c
  -}
-evaluateTree : SpecTree -> 
-               SpecState -> 
-               (around : IO SpecResult -> IO SpecResult) -> 
-               (storeOutput : Bool) -> 
-               (level : Nat) -> 
+evaluateTree : SpecTree ->
+               SpecState ->
+               (around : IO (SpecResult ()) -> IO (SpecResult ())) ->
+               (storeOutput : Bool) ->
+               (level : Nat) ->
                IO SpecState
 -- description or it
 evaluateTree (Leaf (Left info)) state _ store level         = let out = evalInfo info level in
                                                                   if store then
                                                                     pure $ addLine out state
-                                                                  else do 
+                                                                  else do
                                                                     putStrLn out
                                                                     pure state
 
@@ -68,16 +68,16 @@ evaluateTree (Leaf (Left info)) state _ store level         = let out = evalInfo
 evaluateTree (Leaf (Right specIO)) state around store level = evalResult !(around specIO) state store level
 
 -- recursive step
-evaluateTree (Node left right) state around store level 
+evaluateTree (Node left right) state around store level
   = case left of
         -- node containing a description/it -> new level of output indentation
         (Leaf _) => do newState <- evaluateTree left state around store (level + 1)
                        evaluateTree right newState around store (level + 1)
-                       
+
         _        => do newState <- evaluateTree left state around store level
                        evaluateTree right newState around store level
 
-evaluate : (around : IO SpecResult -> IO SpecResult) -> (storeOutput : Bool) -> SpecTree -> IO SpecState
+evaluate : (around : IO (SpecResult ()) -> IO (SpecResult ())) -> (storeOutput : Bool) -> SpecTree -> IO SpecState
 evaluate around store tree = evaluateTree tree neutral around store 0
 
 randomBase : Integer
@@ -94,9 +94,9 @@ partial
 shuffle : {default randomDouble rand : Integer -> Double} -> SpecTree -> (seed : Integer) -> SpecTree
 shuffle {rand} (Node left@(Leaf _) right@(Leaf _)) seed          = Node left right
 shuffle {rand} (Node left@(Leaf (Left (Describe _))) right) seed = Node left (shuffle {rand = rand} right seed)
-shuffle {rand} (Node left@(Node _ _) right@(Node _ _)) seed      = let randVal  = rand seed 
+shuffle {rand} (Node left@(Node _ _) right@(Node _ _)) seed      = let randVal  = rand seed
                                                                        nextSeed = (cast {to = Integer} randVal) * 100 in
-                                                                     if randVal > 0.5 then 
+                                                                     if randVal > 0.5 then
                                                                        Node (shuffle {rand = rand} left nextSeed) (shuffle {rand = rand} right nextSeed)
                                                                      else
                                                                        Node (shuffle {rand = rand} right nextSeed) (shuffle {rand = rand} left nextSeed)

--- a/src/Specdris/Expectations.idr
+++ b/src/Specdris/Expectations.idr
@@ -8,52 +8,58 @@ import Specdris.Core
 
 ||| Placeholder for the future test implementation. Is listed in the
 ||| final spec result.
-pending : SpecResult
-pending = Pending Nothing
+pending : {auto a : x} -> SpecResult x
+pending {a} = Pending a Nothing
 
 ||| Same as `pending`, just adds a more detailed description
-||| 
+|||
 ||| @ message description of what the spec case should test
-pendingWith : (message : String) -> SpecResult
-pendingWith message = Pending (Just message)
+pendingWith : {auto a : x} -> (message : String) -> SpecResult x
+pendingWith {a} message = Pending a (Just message)
 
 ||| Checks if two elements are equal.
-shouldBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
+shouldBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult ()
 shouldBe actual expected = if actual == expected then
-                             Success
+                             Success ()
                            else
                              BinaryFailure actual expected "not equal"
 
 infixr 7 ===
 
 ||| Checks if two elements are equal
-(===) : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
+(===) : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult ()
 (===) = shouldBe
 
 ||| Checks if two element are unequal
-shouldNotBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
+shouldNotBe : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult ()
 shouldNotBe actual expected = if actual /= expected then
-                                Success
+                                Success ()
                               else
                                 BinaryFailure actual expected "equal"
 
 infixr 7 /==
 
 ||| Checks if two element are unequal
-(/==) : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult
+(/==) : (Eq a, Show a) => (actual : a) -> (expected : a) -> SpecResult ()
 (/==) = shouldNotBe
 
 ||| Checks if the given element auf type `Bool` is `True`
-shouldBeTrue : (actual : Bool) -> SpecResult
+shouldBeTrue : (actual : Bool) -> SpecResult ()
 shouldBeTrue actual = actual === True
 
 ||| Checks if the given element auf type `Bool` is `False`
-shouldBeFalse : (actual : Bool) -> SpecResult
+shouldBeFalse : (actual : Bool) -> SpecResult ()
 shouldBeFalse actual = actual === False
 
 ||| Checks if the given element satisfies the predicate
-shouldSatisfy : Show a => (actual : a) -> (pred : a -> Bool) -> SpecResult
+shouldSatisfy : Show a => (actual : a) -> (pred : a -> Bool) -> SpecResult ()
 shouldSatisfy actual pred = if pred actual then
-                              Success
+                              Success ()
                             else
                               UnaryFailure actual "doesn't satisfy predicate"
+
+||| Checks if the given element is (Just x), returning x in the SpecResult
+shouldBeJust : Show x => (actual : Maybe x) -> SpecResult x
+shouldBeJust actual = case actual of
+                         Nothing => UnaryFailure actual "is Nothing"
+                         Just x => Success x

--- a/src/Specdris/Spec.idr
+++ b/src/Specdris/Spec.idr
@@ -24,7 +24,7 @@ describe descr tree = Node (Leaf $ Left $ Describe descr)
 ||| Adds a spec case to the spec test. Spec cases consist only
 ||| of expectations. Nested spec cases or descriptions are not
 ||| allowed.
-it : (description : String) -> SpecResult -> SpecTree
+it : (description : String) -> SpecResult () -> SpecTree
 it descr spec = Node (Leaf $ Left $ It $ descr)
                      (Leaf $ Right $ pure spec)
 
@@ -37,9 +37,9 @@ specWithState {storeOutput} tree
 spec : SpecTree -> IO ()
 spec tree
   = do state <- specWithState tree
-  
+
        putStrLn $ "\n" ++ stateToStr state
-       
+
        if (failed state) > 0 then
          exitFailure
        else

--- a/src/Specdris/SpecIO.idr
+++ b/src/Specdris/SpecIO.idr
@@ -25,7 +25,7 @@ describe descr tree = Node (Leaf $ Left $ Describe descr)
 ||| Adds a spec case to the spec test. Spec cases consist only
 ||| of expectations. Nested spec cases or descriptions are not
 ||| allowed.
-it : (description : String) -> IO SpecResult -> SpecTree
+it : (description : String) -> IO (SpecResult ()) -> SpecTree
 it descr spec = Node (Leaf $ Left $ It  descr)
                      (Leaf $ Right spec)
 
@@ -34,7 +34,7 @@ defaultIO : IO ()
 defaultIO = pure ()
 
 ||| No `around` effect, just returns the given spec case
-noAround : IO SpecResult -> IO SpecResult
+noAround : IO (SpecResult ()) -> IO (SpecResult ())
 noAround spec = spec
 
 ||| Executes a spec test.
@@ -44,10 +44,10 @@ noAround spec = spec
 ||| @ around a function to perform effects before/after every spec case (optional)
 specIOWithState : {default defaultIO beforeAll : IO ()} ->
                   {default defaultIO afterAll : IO ()} ->
-                  {default noAround around : IO SpecResult -> IO SpecResult} ->
+                  {default noAround around : IO (SpecResult ()) -> IO (SpecResult ())} ->
                   {default False storeOutput : Bool} ->
-                
-                  SpecTree -> 
+
+                  SpecTree ->
                   IO SpecState
 specIOWithState {beforeAll} {around} tree {afterAll} {storeOutput}
   = do beforeAll
@@ -63,16 +63,16 @@ specIOWithState {beforeAll} {around} tree {afterAll} {storeOutput}
 ||| @ around a function to perform effects before/after every spec case (optional)
 specIO : {default defaultIO beforeAll : IO ()} ->
          {default defaultIO afterAll : IO ()} ->
-         {default noAround around : IO SpecResult -> IO SpecResult} ->
+         {default noAround around : IO (SpecResult ()) -> IO (SpecResult ())} ->
          {default False storeOutput : Bool} ->
-       
+
          SpecTree ->
          IO ()
 specIO {beforeAll} {around} tree {afterAll} {storeOutput}
   = do state <- specIOWithState {beforeAll = beforeAll} {afterAll = afterAll} {around = around} {storeOutput = storeOutput} tree
-    
+
        putStrLn $ "\n" ++ stateToStr state
-       
+
        if (failed state) > 0 then
          exitFailure
        else

--- a/test/Specdris/ExpectationsTest.idr
+++ b/test/Specdris/ExpectationsTest.idr
@@ -12,14 +12,14 @@ import Specdris.TestUtil
 %access private
 %default total
 
-test : (description : String) -> SpecResult -> SpecTree
+test : (description : String) -> SpecResult () -> SpecTree
 test descr spec = Node (Leaf $ Left $ Describe descr)
                        (Leaf $ Right $ pure spec)
 
 showTestCase : String -> String
 showTestCase test = "expectation_" ++ test
 
-noAround : IO SpecResult -> IO SpecResult
+noAround : IO (SpecResult ()) -> IO (SpecResult ())
 noAround spec = spec
 
 testPending : IO ()
@@ -34,7 +34,7 @@ testEqual : IO ()
 testEqual
   = do state1 <- evaluate noAround False $ test (showTestCase "shouldBe") $ 1 `shouldBe` 1
        state2 <- evaluate noAround False $ test (showTestCase "===") $ 1 === 2
-       
+
        testAndPrint "equal" state1 (MkState 1 0 0 Nothing) (==)
        testAndPrint "===" state2 (MkState 1 1 0 Nothing) (==)
 
@@ -42,7 +42,7 @@ testUnequal : IO ()
 testUnequal
   = do state1 <- evaluate noAround False $ test (showTestCase "shouldNotBe") $ 1 `shouldNotBe` 2
        state2 <- evaluate noAround False $ test (showTestCase "/==") $ 1 /== 1
-  
+
        testAndPrint "unequal" state1 (MkState 1 0 0 Nothing) (==)
        testAndPrint "/==" state2 (MkState 1 1 0 Nothing) (==)
 
@@ -50,7 +50,7 @@ testSatisfy : IO ()
 testSatisfy
   = do state1 <- evaluate noAround False $ test (showTestCase "sat") $ 1 `shouldSatisfy` (> 0)
        state2 <- evaluate noAround False $ test (showTestCase "!sat") $ 1 `shouldSatisfy` (> 1)
-        
+
        testAndPrint "satisfy" state1 (MkState 1 0 0 Nothing) (==)
        testAndPrint "satisfy" state2 (MkState 1 1 0 Nothing) (==)
 

--- a/test/Specdris/SpecIOTest.idr
+++ b/test/Specdris/SpecIOTest.idr
@@ -10,17 +10,17 @@ testCase
                describe "context 1.1" $ do
                  it "context 1.1.1" $ do
                    a <- pure 1
-                   
+
                    pure $ do a === 2
-                             a === 1                  
-        
+                             a === 1
+
                it "context 1.2" $ do
-                 pure $ "hello" `shouldSatisfy` (\str => (length str) > 5)          
+                 pure $ "hello" `shouldSatisfy` (\str => (length str) > 5)
                it "context 1.3" $ do
                  pure $ 1 `shouldBe` 2
                it "context 1.4" $ do
                  pure $ pendingWith "for some reason"
-       
+
        testAndPrint "spec io test" state (MkState 4 3 1 Nothing) (==)
 
 withBeforeAndAfterAll : IO ()
@@ -31,13 +31,13 @@ withBeforeAndAfterAll
                       pure $ 1 === 1
 
        testAndPrint "spec io test with before and after all" state (MkState 1 0 0 Nothing) (==)
-       
 
-around : IO SpecResult -> IO SpecResult
+
+around : IO (SpecResult ()) -> IO (SpecResult ())
 around spec = do putStrLn "before"
                  result <- spec
                  putStrLn "after"
-                 
+
                  pure result
 
 withAround : IO ()
@@ -47,7 +47,7 @@ withAround
                     it "context 1.1" $ do
                       putStrLn "      => expectation"
                       pure $ 1 === 1
-       
+
        testAndPrint "spec io test with around" state (MkState 1 0 0 Nothing) (==)
 
 export


### PR DESCRIPTION
So, I want to write a test that checks that some value is `Just x`, where `x` also passes some other set of checks.

I could not find a neat way of doing this, so I drafted a change to the library that would make this possible, by allowing expectations to return values, as in the following example (also see the pull request changes):

```
justASpec : SpecTree
justASpec = describe "Two-part test" $ do
              it "3 should map to 'b'" $ do
                x <- shouldBeJust (lookup 3 [(4, 'a'), (3, 'b')])
                x === 'b'
```

Is there some way of writing this sort of test conveniently using current specdris? If not, would this be a sensible change to make to the library?

Thanks
