### PR TITLE
Add expectations for Maybe types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ cd specdris
 ### Expectations
 Currently this framework provides you with:
 
-|Expecation|Alias|Description|
+|Expectation|Alias|Description|
 |----------|-----|-----------|
 |`a shouldBe b`|`===`|is `a` equal to `b`|
 |`a shouldNotBe b`|`/==`|is `a` unequal to `b`|
 |`a shouldBeTrue`| |is `a` `True`|
 |`a shouldBeFalse` | | is `a` `False`|
 |`a shouldSatisfy pred`| | satisfies `a` a given predicate|
+|`a shouldBeJust exp` | | if `a` is `Just a'` apply `exp` to `a'`; here `exp` is again a sequence of expectations |
 
 ### Failed Test Cases
 If an expectations in a test case failes the following expectations aren't executed and the

--- a/src/Specdris/Expectations.idr
+++ b/src/Specdris/Expectations.idr
@@ -58,10 +58,12 @@ shouldSatisfy actual pred = if pred actual then
                             else
                               UnaryFailure actual "doesn't satisfy predicate"
 
+||| Checks if the given `Maybe` element is `Just` and satisfies further expectations
 shouldBeJust : Show a => (actual : Maybe a) -> (expectation : a -> SpecResult) -> SpecResult
 shouldBeJust (Just a) expectation = expectation a
 shouldBeJust {a} Nothing _        = UnaryFailure (Nothing {a}) "is not `Just`"
 
+||| Checks if the given `Maybe` element is `Nothing`
 shouldBeNothing : Show a => (actual: Maybe a) -> SpecResult
 shouldBeNothing Nothing = Success
 shouldBeNothing actual  = UnaryFailure actual "is not `Nothing`"

--- a/src/Specdris/Expectations.idr
+++ b/src/Specdris/Expectations.idr
@@ -57,3 +57,6 @@ shouldSatisfy actual pred = if pred actual then
                               Success
                             else
                               UnaryFailure actual "doesn't satisfy predicate"
+
+shouldBeWith : (actual : a) -> (expectation : a -> SpecResult) -> SpecResult
+shouldBeWith actual expectation = expectation actual

--- a/src/Specdris/Expectations.idr
+++ b/src/Specdris/Expectations.idr
@@ -58,5 +58,10 @@ shouldSatisfy actual pred = if pred actual then
                             else
                               UnaryFailure actual "doesn't satisfy predicate"
 
-shouldBeWith : (actual : a) -> (expectation : a -> SpecResult) -> SpecResult
-shouldBeWith actual expectation = expectation actual
+shouldBeJust : Show a => (actual : Maybe a) -> (expectation : a -> SpecResult) -> SpecResult
+shouldBeJust (Just a) expectation = expectation a
+shouldBeJust {a} Nothing _        = UnaryFailure (Nothing {a}) "is not `Just`"
+
+shouldBeNothing : Show a => (actual: Maybe a) -> SpecResult
+shouldBeNothing Nothing = Success
+shouldBeNothing actual  = UnaryFailure actual "is not `Nothing`"

--- a/test/Specdris/ExpectationsTest.idr
+++ b/test/Specdris/ExpectationsTest.idr
@@ -54,23 +54,21 @@ testSatisfy
        testAndPrint "satisfy" state1 (MkState 1 0 0 Nothing) (==)
        testAndPrint "satisfy" state2 (MkState 1 1 0 Nothing) (==)
 
-record ComplexType where
-  constructor MkType
+testShouldBeJust : IO ()
+testShouldBeJust
+  = do state1 <- evaluate noAround False $ test (showTestCase "shouldBeJust") $ (Just "hello") `shouldBeJust` (=== "hello")
+       state2 <- evaluate noAround False $ test (showTestCase "shouldBeJust") $ Nothing `shouldBeJust` (=== "world")
   
-  a : Nat
-  b : String
+       testAndPrint "shouldBeJust" state1 (MkState 1 0 0 Nothing) (==)
+       testAndPrint "shouldBeJust" state2 (MkState 1 1 0 Nothing) (==)
 
-testShouldBeWith : IO ()
-testShouldBeWith
-  = do state1 <- evaluate noAround False $ test (showTestCase "shouldBeWith") $ (MkType 1 "hello") `shouldBeWith` (\x => do 
-         a x === 1
-         b x === "hello")
-       state2 <- evaluate noAround False $ test (showTestCase "shouldBeWith") $ (MkType 1 "hello") `shouldBeWith` (\x => do 
-         a x === 1
-         b x === "world")
+testShouldBeNothing : IO ()
+testShouldBeNothing
+  = do state1 <- evaluate noAround False $ test (showTestCase "shouldBeNothing") $ (shouldBeNothing (Just "hello"))
+       state2 <- evaluate noAround False $ test (showTestCase "shouldBeNothing") $ shouldBeNothing {a = String} Nothing
   
-       testAndPrint "shouldBeWith" state1 (MkState 1 0 0 Nothing) (==)
-       testAndPrint "shouldBeWith" state2 (MkState 1 1 0 Nothing) (==)
+       testAndPrint "shouldBeNothing" state1 (MkState 1 1 0 Nothing) (==)
+       testAndPrint "shouldBeNothing" state2 (MkState 1 0 0 Nothing) (==)
 
 export
 specSuite : IO ()
@@ -79,4 +77,5 @@ specSuite = do putStrLn "\n  expectations:"
                testEqual
                testUnequal
                testSatisfy
-               testShouldBeWith
+               testShouldBeJust
+               testShouldBeNothing

--- a/test/Specdris/ExpectationsTest.idr
+++ b/test/Specdris/ExpectationsTest.idr
@@ -54,6 +54,24 @@ testSatisfy
        testAndPrint "satisfy" state1 (MkState 1 0 0 Nothing) (==)
        testAndPrint "satisfy" state2 (MkState 1 1 0 Nothing) (==)
 
+record ComplexType where
+  constructor MkType
+  
+  a : Nat
+  b : String
+
+testShouldBeWith : IO ()
+testShouldBeWith
+  = do state1 <- evaluate noAround False $ test (showTestCase "shouldBeWith") $ (MkType 1 "hello") `shouldBeWith` (\x => do 
+         a x === 1
+         b x === "hello")
+       state2 <- evaluate noAround False $ test (showTestCase "shouldBeWith") $ (MkType 1 "hello") `shouldBeWith` (\x => do 
+         a x === 1
+         b x === "world")
+  
+       testAndPrint "shouldBeWith" state1 (MkState 1 0 0 Nothing) (==)
+       testAndPrint "shouldBeWith" state2 (MkState 1 1 0 Nothing) (==)
+
 export
 specSuite : IO ()
 specSuite = do putStrLn "\n  expectations:"
@@ -61,3 +79,4 @@ specSuite = do putStrLn "\n  expectations:"
                testEqual
                testUnequal
                testSatisfy
+               testShouldBeWith


### PR DESCRIPTION
This PR is related to #17 . (thanks @Dretch)

When you are working with `Maybe a` you might want to test `a` only if it is `Just` and fail otherwise. I added an expectation to support this use case:

```Idris
record User where
  constructor MkUser

  firstName : String
  lastName: String
  age : Nat

user : Maybe User
user = Just $ MkUser "john" "foo" 27

user `shouldBeJust` (\a => do
 age a === 27
 firstName a === "john"
)
```