### PR TITLE
Add more elba info + change manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ project~
 # idris
 *.ibc
 
+# elba
+target
+elba.lock
+
 js-examples/*.js

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ cd specdris
 .\Project.ps1 --install
 ```
 
+### elba
+If you use [elba](https://github.com/elba/elba) to manage your Idris packages,
+you can also add specdris as a dev-dependency to be run during tests. Just add
+the following to the `[dev_dependencies]` section of your package's
+`elba.toml` manifest:
+
+```toml
+[dev_dependencies]
+# snip
+"pheymann/specdris" = { git = "https://github.com/pheymann/specdris" }
+```
+
+Then you'll be able to use specdris from all test targets.
+
 ## Documentation
 ### Expectations
 Currently this framework provides you with:

--- a/elba.toml
+++ b/elba.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git/specdris"
+name = "pheymann/specdris"
 version = "0.1.0"
 authors = ["Paul Heymann"]
 description = "A testing library for Idris"


### PR DESCRIPTION
- Changed the namespace of the elba package for specdris from `git` to `pheymann`, since the latter is more appropriate in this case

- Added relevant elba files to `.gitignore`

- Added some information on using specdris with elba in the README